### PR TITLE
fix: add init profile into profile

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -50,6 +50,24 @@ func Default() *Profile {
 	return defaultProfile
 }
 
+var errUnsupportedService = errors.New("unsupported service")
+
+func InitProfile(profile string) error {
+	if profile != "" {
+		return SetName(profile)
+	} else if profile = GetString("profile"); profile != "" {
+		return SetName(profile)
+	} else if availableProfiles := List(); len(availableProfiles) == 1 {
+		return SetName(availableProfiles[0])
+	}
+
+	if !IsCloud() {
+		return fmt.Errorf("%w: %s", errUnsupportedService, Service())
+	}
+
+	return nil
+}
+
 func newProfile() *Profile {
 	configDir, err := CLIConfigHome()
 	np := &Profile{


### PR DESCRIPTION
adds init profile functionality into `profile.go` so that it all lives in the single profile library