### PR TITLE
CLOUDP-333243: update transport temporarily

### DIFF
--- a/transport/transport.go
+++ b/transport/transport.go
@@ -114,18 +114,6 @@ func (tr *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // NewServiceAccountClient creates a new HTTP client configured for service account authentication.
-// This function does not return http.RoundTripper as atlas-sdk already packages a transport with the client.
-func NewServiceAccountClient(clientID, clientSecret string) *http.Client {
-	cfg := clientcredentials.NewConfig(clientID, clientSecret)
-	if config.OpsManagerURL() != "" {
-		baseURL := strings.TrimSuffix(config.OpsManagerURL(), "/")
-		cfg.TokenURL = baseURL + clientcredentials.TokenAPIPath
-		cfg.RevokeURL = baseURL + clientcredentials.RevokeAPIPath
-	}
-	return cfg.Client(context.Background())
-}
-
-// NewServiceAccountClientWithHost creates a new HTTP client configured for service account authentication with a custom host.
 // Adding this temporarily until we move config.OpsManagerURL() to this package.
 func NewServiceAccountClientWithHost(clientID, clientSecret, host string) *http.Client {
 	cfg := clientcredentials.NewConfig(clientID, clientSecret)

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -113,8 +113,8 @@ func (tr *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return tr.base.RoundTrip(req)
 }
 
-// NewServiceAccountClient creates a new HTTP client configured for service account authentication.
-// Adding this temporarily until we move config.OpsManagerURL() to this package.
+// NewServiceAccountClientWithHost creates a new HTTP client configured for service account authentication.
+// This function does not return http.RoundTripper as atlas-sdk already packages a transport with the client.
 func NewServiceAccountClientWithHost(clientID, clientSecret, host string) *http.Client {
 	cfg := clientcredentials.NewConfig(clientID, clientSecret)
 	if host != "" {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -124,3 +124,15 @@ func NewServiceAccountClient(clientID, clientSecret string) *http.Client {
 	}
 	return cfg.Client(context.Background())
 }
+
+// NewServiceAccountClientWithHost creates a new HTTP client configured for service account authentication with a custom host.
+// Adding this temporarily until we move config.OpsManagerURL() to this package.
+func NewServiceAccountClientWithHost(clientID, clientSecret, host string) *http.Client {
+	cfg := clientcredentials.NewConfig(clientID, clientSecret)
+	if host != "" {
+		baseURL := strings.TrimSuffix(host, "/")
+		cfg.TokenURL = baseURL + clientcredentials.TokenAPIPath
+		cfg.RevokeURL = baseURL + clientcredentials.RevokeAPIPath
+	}
+	return cfg.Client(context.Background())
+}

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -65,7 +65,7 @@ func TestNewServiceAccountTransport(t *testing.T) {
 	clientID := "mock-client-id"
 	clientSecret := "mock-client-secret" //nolint:gosec
 
-	client := NewServiceAccountClient(clientID, clientSecret)
+	client := NewServiceAccountClientWithHost(clientID, clientSecret, tokenServer.URL)
 	require.NotNil(t, client)
 
 	// Create request to check authentication header


### PR DESCRIPTION
## Proposed changes

Adds temporary `NewServiceAccountClientWithHost` until we finish moving credentials

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
