### PR TITLE
CLOUDP-333242: Adds config version check to LoadAtlasCLIConfig

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,7 @@ func LoadAtlasCLIConfigWithVersion(expectedVersion int64) (*Profile, error) {
 func verifyConfigVersion(expectedVersion int64, s Store) error {
 	rawVersion := s.GetGlobalValue("version")
 	if rawVersion == nil || rawVersion == "" {
+		// Scenario 1: User upgrades plugin but not AtlasCLI.
 		return fmt.Errorf("config version is missing, expected version %d. Please upgrade to a newer version of AtlasCLI", expectedVersion)
 	}
 
@@ -91,10 +92,12 @@ func verifyConfigVersion(expectedVersion int64, s Store) error {
 	}
 	// If version is greater than expectedVersion, the plugin is outdated.
 	if version > expectedVersion {
+		// Scenario 2: Plugin expects outdated configuration version and should be updated.
 		return fmt.Errorf("config version %d is newer than expected version %d. Please upgrade to a newer version of this plugin", version, expectedVersion)
 	}
 	// If version is less than than expectedVersion, the AtlasCLI is outdated.
 	if version < expectedVersion {
+		// Scenario 3: User upgrades plugin but not AtlasCLI, which does not support expected configuration version. AtlasCLI should be updated.
 		return fmt.Errorf("config version %d is older than expected version %d. Please upgrade to a newer version of AtlasCLI", version, expectedVersion)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -54,15 +54,15 @@ func LoadAtlasCLIConfig() (*Profile, error) {
 }
 
 // LoadAtlasCLIConfigWithVersion loads configuration with validation for specified
-// version. The expected_version parameter enforces compatibility by rejecting
+// version. The expectedVersion parameter enforces compatibility by rejecting
 // configs that are newer or older than expected.
-func LoadAtlasCLIConfigWithVersion(expected_version int64) (*Profile, error) {
+func LoadAtlasCLIConfigWithVersion(expectedVersion int64) (*Profile, error) {
 	configStore, initErr := NewDefaultStore()
 	if initErr != nil {
 		return nil, fmt.Errorf("error loading config: %w. Please run `atlas auth login` to reconfigure your profile", initErr)
 	}
 
-	if err := verifyConfigVersion(expected_version, configStore); err != nil {
+	if err := verifyConfigVersion(expectedVersion, configStore); err != nil {
 		return nil, fmt.Errorf("error loading config: %w", err)
 	}
 
@@ -79,23 +79,23 @@ func LoadAtlasCLIConfigWithVersion(expected_version int64) (*Profile, error) {
 // verifyConfigVersion checks if the config version is as expected. This ensures
 // an incompatible version of the config is not loaded and provides useful error
 // messaging to users.
-func verifyConfigVersion(expected_version int64, s Store) error {
-	version := s.GetGlobalValue("version")
-	if version == nil || version == "" {
-		return fmt.Errorf("config version is missing, expected version %d. Please upgrade to a newer version of AtlasCLI", expected_version)
+func verifyConfigVersion(expectedVersion int64, s Store) error {
+	rawVersion := s.GetGlobalValue("version")
+	if rawVersion == nil || rawVersion == "" {
+		return fmt.Errorf("config version is missing, expected version %d. Please upgrade to a newer version of AtlasCLI", expectedVersion)
 	}
 
-	v, ok := version.(int64)
+	version, ok := rawVersion.(int64)
 	if !ok {
-		return fmt.Errorf("invalid config version type: %T", version)
+		return fmt.Errorf("invalid config version type: %T", rawVersion)
 	}
-	// If version is greater than expected_version, the plugin is outdated.
-	if v > expected_version {
-		return fmt.Errorf("config version %d is newer than expected version %d. Please upgrade to a newer version of this plugin", version, expected_version)
+	// If version is greater than expectedVersion, the plugin is outdated.
+	if version > expectedVersion {
+		return fmt.Errorf("config version %d is newer than expected version %d. Please upgrade to a newer version of this plugin", version, expectedVersion)
 	}
-	// If version is less than than expected_version, the AtlasCLI is outdated.
-	if v < expected_version {
-		return fmt.Errorf("config version %d is older than expected version %d. Please upgrade to a newer version of AtlasCLI", version, expected_version)
+	// If version is less than than expectedVersion, the AtlasCLI is outdated.
+	if version < expectedVersion {
+		return fmt.Errorf("config version %d is older than expected version %d. Please upgrade to a newer version of AtlasCLI", version, expectedVersion)
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,9 @@ import (
 	"path"
 )
 
+// MaxSupportedVersion is the maximum supported config version available in AtlasCLI.
+const MaxSupportedVersion = 2
+
 // CLIConfigHome retrieves configHome path.
 func CLIConfigHome() (string, error) {
 	home, err := os.UserConfigDir()
@@ -44,11 +47,23 @@ func Path(f string) (string, error) {
 	return p.String(), nil
 }
 
+// LoadAtlasCLIConfig loads configuration using the maximum supported version,
+// ensuring plugins always use the latest AtlasCLI configuration schema.
 func LoadAtlasCLIConfig() (*Profile, error) {
-	configStore, initErr := NewDefaultStore()
+	return LoadAtlasCLIConfigWithVersion(MaxSupportedVersion)
+}
 
+// LoadAtlasCLIConfigWithVersion loads configuration with validation for specified
+// version. The expected_version parameter enforces compatibility by rejecting
+// configs that are newer or older than expected.
+func LoadAtlasCLIConfigWithVersion(expected_version int64) (*Profile, error) {
+	configStore, initErr := NewDefaultStore()
 	if initErr != nil {
 		return nil, fmt.Errorf("error loading config: %w. Please run `atlas auth login` to reconfigure your profile", initErr)
+	}
+
+	if err := verifyConfigVersion(expected_version, configStore); err != nil {
+		return nil, fmt.Errorf("error loading config: %w", err)
 	}
 
 	if !configStore.IsSecure() {
@@ -59,4 +74,29 @@ func LoadAtlasCLIConfig() (*Profile, error) {
 	SetProfile(profile)
 
 	return profile, nil
+}
+
+// verifyConfigVersion checks if the config version is as expected. This ensures
+// an incompatible version of the config is not loaded and provides useful error
+// messaging to users.
+func verifyConfigVersion(expected_version int64, s Store) error {
+	version := s.GetGlobalValue("version")
+	if version == nil || version == "" {
+		return fmt.Errorf("config version is missing, expected version %d. Please upgrade to a newer version of AtlasCLI", expected_version)
+	}
+
+	v, ok := version.(int64)
+	if !ok {
+		return fmt.Errorf("invalid config version type: %T", version)
+	}
+	// If version is greater than expected_version, the plugin is outdated.
+	if v > expected_version {
+		return fmt.Errorf("config version %d is newer than expected version %d. Please upgrade to a newer version of this plugin", version, expected_version)
+	}
+	// If version is less than than expected_version, the AtlasCLI is outdated.
+	if v < expected_version {
+		return fmt.Errorf("config version %d is older than expected version %d. Please upgrade to a newer version of AtlasCLI", version, expected_version)
+	}
+
+	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/mongodb/atlas-cli-core/mocks"
+	"go.uber.org/mock/gomock"
+)
+
+func TestVerifyConfigVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupMock   func(*mocks.MockStore)
+		expectedVer int64
+		wantErr     bool
+	}{
+		{
+			name: "version matches expected",
+			setupMock: func(m *mocks.MockStore) {
+				m.EXPECT().GetGlobalValue("version").Return(int64(2))
+			},
+			expectedVer: 2,
+			wantErr:     false,
+		},
+		{
+			name: "missing version",
+			setupMock: func(m *mocks.MockStore) {
+				m.EXPECT().GetGlobalValue("version").Return(nil)
+			},
+			expectedVer: 2,
+			wantErr:     true,
+		},
+		{
+			name: "version newer than expected",
+			setupMock: func(m *mocks.MockStore) {
+				m.EXPECT().GetGlobalValue("version").Return(int64(3))
+			},
+			expectedVer: 2,
+			wantErr:     true,
+		},
+		{
+			name: "version older than expected",
+			setupMock: func(m *mocks.MockStore) {
+				m.EXPECT().GetGlobalValue("version").Return(int64(1))
+			},
+			expectedVer: 2,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockStore := mocks.NewMockStore(ctrl)
+			tt.setupMock(mockStore)
+
+			err := verifyConfigVersion(tt.expectedVer, mockStore)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("verifyConfigVersion() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

PR (3/3)

Makes new function LoadAtlasCLIConfigWithVersion which takes input `expected_version`. This is the version of the config the caller expects to be working with. This enables plugins to warn from their end if the user is using an incompatible config version and provides user-friendly messaging to either upgrade the plugin (if expected_version < actual version) or upgrade the CLI (is expected_version > actual version).

Makes LoadAtlasCLIConfig call LoadAtlasCLIConfigWithVersion with expected_version=MaxSupportedVersion. This enables the caller to allows be loading for the most up-to-date config version (given they frequently bump the library)

Future work:
* CLOUDP-339293 will see to implementing use of atlas-cli-core cred handling.
  * A plugin version check will be done on AtlasCLI side for our 2 existing plugins and warning is provided to upgrade those plugins if version is less than version which will use updated atlas-cli-core.