### PR TITLE
Chore: redacts client secret

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -588,7 +588,7 @@ func (p *Profile) Map() map[string]string {
 	settings := p.configStore.GetProfileStringMap(p.Name())
 	profileSettings := make(map[string]string, len(settings)+1)
 	for k, v := range settings {
-		if k == privateAPIKey || k == AccessTokenField || k == RefreshTokenField {
+		if k == privateAPIKey || k == AccessTokenField || k == RefreshTokenField || k == ClientSecretField {
 			profileSettings[k] = "redacted"
 		} else {
 			profileSettings[k] = v


### PR DESCRIPTION
## Proposed changes
Method Map() replaces some fields with "redacted". This adds client secret to the fields to be redacted.

In AtlasCLI this effects `atlas config describe` for users who don't have secure storage available.