### PR TITLE
Fix: get environment variables for secure properties

### DIFF
--- a/config/proxy_store.go
+++ b/config/proxy_store.go
@@ -112,14 +112,17 @@ func (p *ProxyStore) DeleteProfile(profileName string) error {
 }
 
 // GetHierarchicalValue routes to secure or insecure store based on property type.
+// For secure properties, it first checks the insecure store for a value, in the
+// case that environment variables are used. If no value is found, it will proceed
+// with secure store.
 func (p *ProxyStore) GetHierarchicalValue(profileName string, propertyName string) any {
-	if isSecureProperty(propertyName) {
-		val := p.secure.Get(profileName, propertyName)
-		if val != "" {
-			return val
-		}
+	val := p.insecure.GetHierarchicalValue(profileName, propertyName)
+
+	if isSecureProperty(propertyName) && val == "" {
+		return p.secure.Get(profileName, propertyName)
 	}
-	return p.insecure.GetHierarchicalValue(profileName, propertyName)
+
+	return val
 }
 
 // SetProfileValue routes to secure or insecure store based on property type.

--- a/config/proxy_store.go
+++ b/config/proxy_store.go
@@ -118,7 +118,7 @@ func (p *ProxyStore) DeleteProfile(profileName string) error {
 func (p *ProxyStore) GetHierarchicalValue(profileName string, propertyName string) any {
 	val := p.insecure.GetHierarchicalValue(profileName, propertyName)
 
-	if isSecureProperty(propertyName) && val == "" {
+	if isSecureProperty(propertyName) && val == nil {
 		return p.secure.Get(profileName, propertyName)
 	}
 

--- a/config/proxy_store.go
+++ b/config/proxy_store.go
@@ -114,7 +114,10 @@ func (p *ProxyStore) DeleteProfile(profileName string) error {
 // GetHierarchicalValue routes to secure or insecure store based on property type.
 func (p *ProxyStore) GetHierarchicalValue(profileName string, propertyName string) any {
 	if isSecureProperty(propertyName) {
-		return p.secure.Get(profileName, propertyName)
+		val := p.secure.Get(profileName, propertyName)
+		if val != "" {
+			return val
+		}
 	}
 	return p.insecure.GetHierarchicalValue(profileName, propertyName)
 }

--- a/config/proxy_store_test.go
+++ b/config/proxy_store_test.go
@@ -150,6 +150,9 @@ func testGetHierarchicalValue(t *testing.T, store *ProxyStore, propertyName stri
 	expectedValue := testValue
 
 	if isSecure {
+		store.insecure.(*mocks.MockStore).EXPECT().
+			GetHierarchicalValue(profileName, propertyName).
+			Return(nil)
 		store.secure.(*mocks.MockSecureStore).EXPECT().
 			Get(profileName, propertyName).
 			Return(expectedValue)


### PR DESCRIPTION
## Proposed changes

Secure storage is not able to detect if a value is being set by env vars and so will return nil.

This work fixes that by always getting a property with the insecure store and proceeding with secure store only if nothing was found. The only case where a secure property will be found by insecure store is when an env var is set.

Followup work:
To address how to change auth-type if user uses env vars with an already set profile
