### PR TITLE
fix: remove initAuthType and infer env var authtype in getter

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -315,19 +315,25 @@ const (
 	NoAuth         AuthMechanism = "no_auth"
 )
 
-// AuthType gets the configured auth type.
+// AuthType determines the auth type, prioritizing credentials set via
+// environment variables.
+// It first retrieves the auth type configured in the profile. If programmatic
+// credentials that do not match the profile's auth type are detected, AuthType
+// infers that these credentials were set via environment variables and returns
+// the corresponding auth type.
+// This assumes users will not explicitly export the auth type variable.
 func AuthType() AuthMechanism { return Default().AuthType() }
 func (p *Profile) AuthType() AuthMechanism {
-	configAuthType := AuthMechanism(p.GetString(AuthTypeField))
+	profileAuthType := AuthMechanism(p.GetString(AuthTypeField))
 
-	if configAuthType != ServiceAccount && ClientID() != "" && ClientSecret() != "" {
+	if profileAuthType != ServiceAccount && ClientID() != "" && ClientSecret() != "" {
 		return ServiceAccount
 	}
-	if configAuthType != APIKeys && PrivateAPIKey() != "" && PublicAPIKey() != "" {
+	if profileAuthType != APIKeys && PrivateAPIKey() != "" && PublicAPIKey() != "" {
 		return APIKeys
 	}
 
-	return configAuthType
+	return profileAuthType
 }
 
 // SetAuthType sets the configured auth type.

--- a/config/profile.go
+++ b/config/profile.go
@@ -138,30 +138,7 @@ func InitProfile(profile string) error {
 		return fmt.Errorf("%w: %s", errUnsupportedService, Service())
 	}
 
-	initAuthType()
-
 	return nil
-}
-
-// initAuthType initializes the authentication type based on the current configuration.
-// If the user has set credentials via environment variables and has not set
-// 'MONGODB_ATLAS_AUTH_TYPE', it will set the auth type accordingly.
-func initAuthType() {
-	// If the auth type is already set, we don't need to do anything.
-	authType := AuthType()
-	if authType != "" {
-		return
-	}
-	// If the auth type is not set, we try to determine it based on the available credentials.
-	if PrivateAPIKey() != "" && PublicAPIKey() != "" {
-		SetAuthType(APIKeys)
-	}
-	if AccessToken() != "" && RefreshToken() != "" {
-		SetAuthType(UserAccount)
-	}
-	if ClientID() != "" && ClientSecret() != "" {
-		SetAuthType(ServiceAccount)
-	}
 }
 
 func AllProperties() []string {
@@ -341,7 +318,16 @@ const (
 // AuthType gets the configured auth type.
 func AuthType() AuthMechanism { return Default().AuthType() }
 func (p *Profile) AuthType() AuthMechanism {
-	return AuthMechanism(p.GetString(AuthTypeField))
+	configAuthType := AuthMechanism(p.GetString(AuthTypeField))
+
+	if configAuthType != ServiceAccount && ClientID() != "" && ClientSecret() != "" {
+		return ServiceAccount
+	}
+	if configAuthType != APIKeys && PrivateAPIKey() != "" && PublicAPIKey() != "" {
+		return APIKeys
+	}
+
+	return configAuthType
 }
 
 // SetAuthType sets the configured auth type.


### PR DESCRIPTION
## Proposed changes

### Issue: 
initAuthType was created to initialise the authtype when using env vars. This method uses setAuthType so that the env var authType will be retrieved when running the getting func AuthType. This has the effect of modifying the config for the runtime, resulting in inaccurate `atlas config describe`. The func also does not prioritise env vars as the CLI does.

### Solution: 
* Remove initAuthType
* Change getting function AuthType to infer if env var is being used

### Assumption:
This approach makes the assumption that a user is not exporting the AuthType already.

--- 
### Testing:
Manual testing involved importing the library into CLI and running the following scenarios
* Remove default profile
* export api keys
  * run `atlas config list`
    * no default profile present
  * run `atlas config describe <service account profile>`
    * auth type is not modified to api-keys
  * run `atlas cluster list`
    * cmd succeeded
  * run `atlas cluster list --profile <profile using different cloud env>`
    * cmd succeeded - still shows clusters from first cloud env

---
### Follow-up work:
* AtlasCLI: 
  * Upgrade core dep and replace InitProfile with core.InitProfile
* Kubernetese Plugin:
  * Upgrade library and replace all functions covered by Core with the core implementation