### PR TITLE
fix: stores secure creds as redacted in insecure storage

### DIFF
--- a/config/proxy_store.go
+++ b/config/proxy_store.go
@@ -22,6 +22,7 @@ package config
 import (
 	"errors"
 	"slices"
+	"strings"
 
 	"github.com/mongodb/atlas-cli-core/config/secure"
 	"github.com/spf13/afero"
@@ -113,23 +114,27 @@ func (p *ProxyStore) DeleteProfile(profileName string) error {
 
 // GetHierarchicalValue routes to secure or insecure store based on property type.
 // For secure properties, it first checks the insecure store for a value, in the
-// case that environment variables are used. If no value is found, it will proceed
-// with secure store.
+// case that environment variables are used. If no valid value is found, it will
+// proceed with secure store.
 func (p *ProxyStore) GetHierarchicalValue(profileName string, propertyName string) any {
 	val := p.insecure.GetHierarchicalValue(profileName, propertyName)
 
-	if isSecureProperty(propertyName) && val == nil {
-		return p.secure.Get(profileName, propertyName)
+	if isSecureProperty(propertyName) && (val == nil || strings.EqualFold(val.(string), "redacted")) {
+		val = p.secure.Get(profileName, propertyName)
 	}
 
 	return val
 }
 
 // SetProfileValue routes to secure or insecure store based on property type.
+// For secure properties, it stores the actual value in secure storage and
+// a "redacted" placeholder in the insecure store. This allows users to see
+// that a secure value is set without storing the sensitive data in insecure storage.
 func (p *ProxyStore) SetProfileValue(profileName string, propertyName string, value any) {
 	if isSecureProperty(propertyName) {
 		if v, ok := value.(string); ok {
 			p.secure.Set(profileName, propertyName, v)
+			p.insecure.SetProfileValue(profileName, propertyName, "redacted")
 		}
 		return
 	}
@@ -137,11 +142,17 @@ func (p *ProxyStore) SetProfileValue(profileName string, propertyName string, va
 }
 
 // GetProfileValue routes to secure or insecure store based on property type.
+// For secure properties, it first checks the insecure store for a value, in the
+// case that environment variables are used. If no valid value is found, it will
+// proceed with secure store.
 func (p *ProxyStore) GetProfileValue(profileName string, propertyName string) any {
-	if isSecureProperty(propertyName) {
-		return p.secure.Get(profileName, propertyName)
+	val := p.insecure.GetProfileValue(profileName, propertyName)
+
+	if isSecureProperty(propertyName) && (val == nil || strings.EqualFold(val.(string), "redacted")) {
+		val = p.secure.Get(profileName, propertyName)
 	}
-	return p.insecure.GetProfileValue(profileName, propertyName)
+
+	return val
 }
 
 // GetProfileStringMap returns insecure properties only, excluding secure values.

--- a/config/proxy_store_test.go
+++ b/config/proxy_store_test.go
@@ -152,7 +152,7 @@ func testGetHierarchicalValue(t *testing.T, store *ProxyStore, propertyName stri
 	if isSecure {
 		store.insecure.(*mocks.MockStore).EXPECT().
 			GetHierarchicalValue(profileName, propertyName).
-			Return(nil)
+			Return("redacted")
 		store.secure.(*mocks.MockSecureStore).EXPECT().
 			Get(profileName, propertyName).
 			Return(expectedValue)
@@ -174,6 +174,8 @@ func testSetProfileValue(t *testing.T, store *ProxyStore, propertyName string, i
 	if isSecure {
 		store.secure.(*mocks.MockSecureStore).EXPECT().
 			Set(profileName, propertyName, value)
+		store.insecure.(*mocks.MockStore).EXPECT().
+			SetProfileValue(profileName, propertyName, "redacted")
 	} else {
 		store.insecure.(*mocks.MockStore).EXPECT().
 			SetProfileValue(profileName, propertyName, value)
@@ -191,6 +193,9 @@ func testGetProfileValue(t *testing.T, store *ProxyStore, propertyName string, i
 		store.secure.(*mocks.MockSecureStore).EXPECT().
 			Get(profileName, propertyName).
 			Return(expectedValue)
+		store.insecure.(*mocks.MockStore).EXPECT().
+			GetProfileValue(profileName, propertyName).
+			Return("redacted")
 	} else {
 		store.insecure.(*mocks.MockStore).EXPECT().
 			GetProfileValue(profileName, propertyName).


### PR DESCRIPTION
## Proposed changes

To allow users to see what credentials are being stored when running `atlas config describe` without exposing the data, a secure property will be set in secure storage with the actual value as well as in insecure storage with value "redacted".

In this way, users should not get confused if they get an `Unauthorized` error and check their config to see their keys are missing.

```
# profile shows secure properties with value redacted
> bin/atlas config describe profileName
SETTING         VALUE
auth_type       service_account
client_id       redacted
client_secret   redacted
org_id          b1234bcde5678fghi9012jk
output          plaintext
project_id      a1234bcde5678fghi9012jk
service         cloud

# secure credentials are correctly retrieved, allowing for successful api calls
> bin/atlas cluster list -P profileName
ID    NAME   MDB VER   STATE

# exporting credentials is not effected by this change
> export <credentials set to another project/org>
> bin/atlas cluster list -P profileName
ID                         NAME           MDB VER   STATE
12abc3456def7g8h8ee96d3f   Cluster11111   8.0.13    IDLE
```

## Follow-up Actions
* Bump core dep in AtlasCLI
* Bump core dep in K8s Plugin


## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
