### PR TITLE
CLOUDP-343204: adds global config property `silence_storage_warning`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -66,8 +66,10 @@ func LoadAtlasCLIConfigWithVersion(expectedVersion int64) (*Profile, error) {
 		return nil, fmt.Errorf("error loading config: %w", err)
 	}
 
-	if !configStore.IsSecure() {
-		fmt.Fprintf(os.Stderr, "Warning: Secure storage is not available, falling back to insecure storage\n")
+	if !configStore.IsSecure() && !SilenceStorageWarning() {
+		fmt.Fprintf(os.Stderr, `Warning: Secure storage is not available, falling back to insecure storage
+		
+		To disable this alert, run "atlas config set silence_storage_warning true"`)
 	}
 
 	profile := NewProfile(DefaultProfile, configStore)

--- a/config/profile.go
+++ b/config/profile.go
@@ -56,6 +56,7 @@ const (
 	configPerm               = 0600
 	defaultPermissions       = 0700
 	skipUpdateCheck          = "skip_update_check"
+	silenceStorageWarning    = "silence_storage_warning"
 	TelemetryEnabledProperty = "telemetry_enabled"
 	AtlasCLI                 = "atlascli"
 	ContainerizedHostNameEnv = "MONGODB_ATLAS_IS_CONTAINERIZED"
@@ -148,6 +149,7 @@ func AllProperties() []string {
 func BooleanProperties() []string {
 	return []string{
 		skipUpdateCheck,
+		silenceStorageWarning,
 		TelemetryEnabledProperty,
 	}
 }
@@ -176,6 +178,7 @@ func GlobalProperties() []string {
 		LocalDeploymentImage,
 		mongoShellPath,
 		skipUpdateCheck,
+		silenceStorageWarning,
 		TelemetryEnabledProperty,
 	}
 }
@@ -519,6 +522,18 @@ func (p *Profile) SkipUpdateCheck() bool {
 func SetSkipUpdateCheck(v bool) { Default().SetSkipUpdateCheck(v) }
 func (*Profile) SetSkipUpdateCheck(v bool) {
 	SetGlobal(skipUpdateCheck, v)
+}
+
+// SilenceStorageWarning get the global silence storage warning.
+func SilenceStorageWarning() bool { return Default().SilenceStorageWarning() }
+func (p *Profile) SilenceStorageWarning() bool {
+	return p.GetBool(silenceStorageWarning)
+}
+
+// SetSilenceStorageWarning sets the global silence storage warning.
+func SetSilenceStorageWarning(v bool) { Default().SetSilenceStorageWarning(v) }
+func (*Profile) SetSilenceStorageWarning(v bool) {
+	SetGlobal(silenceStorageWarning, v)
 }
 
 // IsTelemetryEnabledSet return true if telemetry_enabled has been set.

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -272,6 +272,7 @@ func withNewConfig(t *testing.T) {
 	configPath := path.Join(dir, "config.toml")
 
 	err := os.WriteFile(configPath, []byte(`
+  silence_storage_warning = true
   version = 2
   [config_test]
   org_id = "new_config_org_id"

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -272,8 +272,8 @@ func withNewConfig(t *testing.T) {
 	configPath := path.Join(dir, "config.toml")
 
 	err := os.WriteFile(configPath, []byte(`
-  silence_storage_warning = true
   version = 2
+  silence_storage_warning = true
   [config_test]
   org_id = "new_config_org_id"
   client_id = "new_config_client_id"

--- a/test/e2e/profile_test.go
+++ b/test/e2e/profile_test.go
@@ -73,7 +73,8 @@ func TestProfileValidation(t *testing.T) {
 		viper.Reset()
 
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `version = 2
+		configContent := `silence_storage_warning = true
+version = 2
 
 [invalid-service]
 project_id = "test_project"
@@ -95,7 +96,8 @@ service = "unsupported"
 		viper.Reset()
 
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `version = 2
+		configContent := `silence_storage_warning = true
+version = 2
 
 [cloud-profile]
 project_id = "test_project"
@@ -139,7 +141,8 @@ project_id = "test_project"
 		viper.Reset()
 
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `version = 2
+		configContent := `silence_storage_warning = true
+version = 2
 
 [test-profile]
 project_id = "test_project"
@@ -192,7 +195,8 @@ func TestMultipleProfilesE2E(t *testing.T) {
 
 		// Create config with multiple profiles
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `version = 2
+		configContent := `silence_storage_warning = true
+version = 2
 
 [dev]
 project_id = "dev_project"
@@ -229,7 +233,8 @@ service = "cloud"
 		viper.Reset()
 
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `version = 2
+		configContent := `silence_storage_warning = true
+version = 2
 
 [dev]
 project_id = "dev_project"
@@ -264,7 +269,8 @@ service = "cloud"
 		viper.Reset()
 
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `version = 2
+		configContent := `silence_storage_warning = true
+version = 2
 
 [single-profile]
 project_id = "single_project"
@@ -288,7 +294,8 @@ service = "cloud"
 		viper.Reset()
 
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `version = 2
+		configContent := `silence_storage_warning = true
+version = 2
 
 [old-name]
 project_id = "test_project"

--- a/test/e2e/profile_test.go
+++ b/test/e2e/profile_test.go
@@ -73,8 +73,8 @@ func TestProfileValidation(t *testing.T) {
 		viper.Reset()
 
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `silence_storage_warning = true
-version = 2
+		configContent := `version = 2
+silence_storage_warning = true
 
 [invalid-service]
 project_id = "test_project"
@@ -96,8 +96,8 @@ service = "unsupported"
 		viper.Reset()
 
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `silence_storage_warning = true
-version = 2
+		configContent := `version = 2
+silence_storage_warning = true
 
 [cloud-profile]
 project_id = "test_project"
@@ -141,8 +141,8 @@ project_id = "test_project"
 		viper.Reset()
 
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `silence_storage_warning = true
-version = 2
+		configContent := `version = 2
+silence_storage_warning = true
 
 [test-profile]
 project_id = "test_project"
@@ -195,8 +195,8 @@ func TestMultipleProfilesE2E(t *testing.T) {
 
 		// Create config with multiple profiles
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `silence_storage_warning = true
-version = 2
+		configContent := `version = 2
+silence_storage_warning = true
 
 [dev]
 project_id = "dev_project"
@@ -233,8 +233,8 @@ service = "cloud"
 		viper.Reset()
 
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `silence_storage_warning = true
-version = 2
+		configContent := `version = 2
+silence_storage_warning = true
 
 [dev]
 project_id = "dev_project"
@@ -269,8 +269,8 @@ service = "cloud"
 		viper.Reset()
 
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `silence_storage_warning = true
-version = 2
+		configContent := `version = 2
+silence_storage_warning = true
 
 [single-profile]
 project_id = "single_project"
@@ -294,8 +294,8 @@ service = "cloud"
 		viper.Reset()
 
 		configPath := filepath.Join(dir, "config.toml")
-		configContent := `silence_storage_warning = true
-version = 2
+		configContent := `version = 2
+silence_storage_warning = true
 
 [old-name]
 project_id = "test_project"


### PR DESCRIPTION
## Proposed changes

* Adds support for global config property `silence_storage_warning`
This property will prevent the warning message `Warning: Secure storage is not available, falling back to insecure storage` from printing
* Added this property to e2e tests, proving this property works as intended

### Follow-up work
* Bump CLI
  * set e2e profiles to contain `silence_storage_warning`
* Bump K8s plugin