### PR TITLE
chore: adds method NewStoreWithEnvOption

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,10 @@ import (
 )
 
 // MaxSupportedVersion is the maximum supported config version available in AtlasCLI.
-const MaxSupportedVersion = 2
+const (
+	MaxSupportedVersion = 2
+	versionKey          = "version"
+)
 
 // CLIConfigHome retrieves configHome path.
 func CLIConfigHome() (string, error) {
@@ -86,12 +89,12 @@ func verifyConfigVersion(expectedVersion int64, s Store) error {
 		return nil
 	}
 
-	if !s.IsSetGlobal("version") {
+	if !s.IsSetGlobal(versionKey) {
 		// Scenario 1: User upgrades plugin but not AtlasCLI.
 		return fmt.Errorf("config version is missing, expected version %d. Please upgrade to a newer version of AtlasCLI", expectedVersion)
 	}
 
-	rawVersion := s.GetGlobalValue("version")
+	rawVersion := s.GetGlobalValue(versionKey)
 	version, ok := rawVersion.(int64)
 	if !ok {
 		return fmt.Errorf("invalid config version type: %T", rawVersion)

--- a/config/profile.go
+++ b/config/profile.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -572,34 +571,6 @@ func (p *Profile) IsAccessSet() bool {
 		p.ClientID() != "" && p.ClientSecret() != ""
 
 	return isSet
-}
-
-// Map returns a map describing the configuration.
-func Map() map[string]string { return Default().Map() }
-func (p *Profile) Map() map[string]string {
-	settings := p.configStore.GetProfileStringMap(p.Name())
-	profileSettings := make(map[string]string, len(settings)+1)
-	for k, v := range settings {
-		if k == privateAPIKey || k == AccessTokenField || k == RefreshTokenField || k == ClientSecretField {
-			profileSettings[k] = "redacted"
-		} else {
-			profileSettings[k] = v
-		}
-	}
-
-	return profileSettings
-}
-
-// SortedKeys returns the properties of the Profile sorted.
-func SortedKeys() []string { return Default().SortedKeys() }
-func (p *Profile) SortedKeys() []string {
-	config := p.Map()
-	keys := make([]string, 0, len(config))
-	for k := range config {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }
 
 // Delete deletes an existing configuration. The profiles are reloaded afterwards, as

--- a/config/proxy_store.go
+++ b/config/proxy_store.go
@@ -45,7 +45,13 @@ type ProxyStore struct {
 
 // NewDefaultStore creates a store with default filesystem and secure storage if available.
 func NewDefaultStore() (Store, error) {
-	insecure, err := NewViperStore(afero.NewOsFs(), true)
+	return NewStoreWithEnvOption(true)
+}
+
+// NewStoreWithEnvOption creates a store with default filesystem and secure storage
+// if available. It will load environment variables according to the loadEnvVars input.
+func NewStoreWithEnvOption(loadEnvVars bool) (Store, error) {
+	insecure, err := NewViperStore(afero.NewOsFs(), loadEnvVars)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Proposed changes

* Adds method `NewStoreWithEnvOption`
  * This method will be used by `atlas config describe` to retrieve all properties stored without env vars
* Removes `Map()` and `sortKey` as these methods will not be used after the follow-up work in atlasCLI

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
