### PR TITLE
fix: moves warning to after profile is initialised

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -69,15 +69,15 @@ func LoadAtlasCLIConfigWithVersion(expectedVersion int64) (*Profile, error) {
 		return nil, fmt.Errorf("error loading config: %w", err)
 	}
 
+	profile := NewProfile(DefaultProfile, configStore)
+	SetProfile(profile)
+
 	if !configStore.IsSecure() && !SilenceStorageWarning() {
 		fmt.Fprintf(os.Stderr, `
 Warning: Secure storage is not available, falling back to insecure storage
 To disable this alert, run "atlas config set silence_storage_warning true"
 `)
 	}
-
-	profile := NewProfile(DefaultProfile, configStore)
-	SetProfile(profile)
 
 	return profile, nil
 }


### PR DESCRIPTION
## Proposed changes

Warning suppression was not working properly with the global flag as global variables are only accessible from SilenceStorageWarning() after the profile is initialised

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
