### PR TITLE
fix(config): add environment variable layer to ProxyStore for credential resolution

### DIFF
--- a/config/proxy_store.go
+++ b/config/proxy_store.go
@@ -38,9 +38,15 @@ var SecureProperties = []string{
 }
 
 // ProxyStore routes properties between secure and insecure stores based on property type.
+// It implements a three-layer priority system for secure properties:
+// 1. Environment variables (highest priority)
+// 2. Secure store (keyring)
+// 3. Config file (lowest priority)
+// Both environment and secure are nil when not available.
 type ProxyStore struct {
-	insecure Store
-	secure   SecureStore
+	environment Store       // Viper with no filesystem, only environment variables; nil if not loaded
+	insecure    Store       // Viper with filesystem, no environment variables
+	secure      SecureStore // System keyring; nil if not available
 }
 
 // NewDefaultStore creates a store with default filesystem and secure storage if available.
@@ -51,27 +57,43 @@ func NewDefaultStore() (Store, error) {
 // NewStoreWithEnvOption creates a store with default filesystem and secure storage
 // if available. It will load environment variables according to the loadEnvVars input.
 func NewStoreWithEnvOption(loadEnvVars bool) (Store, error) {
-	insecure, err := NewViperStore(afero.NewOsFs(), loadEnvVars)
-
+	// Create file-based store (no env vars)
+	insecureStore, err := NewViperStore(afero.NewOsFs(), false)
 	if err != nil {
 		return nil, err
 	}
 
-	profileNames := insecure.GetProfileNames()
+	var environmentStore Store
+	if loadEnvVars {
+		// Create environment-only store (in-memory filesystem, no config file)
+		environmentStore, err = NewViperStore(afero.NewMemMapFs(), true)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	profileNames := insecureStore.GetProfileNames()
 	secureStore := secure.NewSecureStore(profileNames, SecureProperties)
 
-	return NewStore(insecure, secureStore), nil
+	return NewStore(environmentStore, insecureStore, secureStore), nil
 }
 
-// NewStore creates a ProxyStore if secure storage is available, otherwise returns insecure store.
-func NewStore(insecureStore Store, secureStore SecureStore) Store {
-	if !secureStore.Available() {
-		return insecureStore
+// NewStore creates a ProxyStore if we have environment or secure storage,
+// otherwise returns insecure store directly.
+func NewStore(environment Store, insecure Store, secureStore SecureStore) Store {
+	var secure SecureStore
+	if secureStore != nil && secureStore.Available() {
+		secure = secureStore
+	}
+
+	if environment == nil && secure == nil {
+		return insecure
 	}
 
 	return &ProxyStore{
-		insecure: insecureStore,
-		secure:   secureStore,
+		environment: environment,
+		insecure:    insecure,
+		secure:      secure,
 	}
 }
 
@@ -82,12 +104,13 @@ func isSecureProperty(propertyName string) bool {
 
 // Store interface implementation for ProxyStore
 
-// IsSecure returns true as ProxyStore provides secure storage capabilities.
-func (*ProxyStore) IsSecure() bool {
-	return true
+// IsSecure returns true if the secure store (keyring) is available.
+func (p *ProxyStore) IsSecure() bool {
+	return p.secure != nil
 }
 
 // Save persists both secure and insecure stores, collecting any errors.
+// Environment store is not persisted as it's read-only.
 func (p *ProxyStore) Save() error {
 	errs := []error{}
 
@@ -95,8 +118,10 @@ func (p *ProxyStore) Save() error {
 		errs = append(errs, err)
 	}
 
-	if err := p.secure.Save(); err != nil {
-		errs = append(errs, err)
+	if p.secure != nil {
+		if err := p.secure.Save(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	return errors.Join(errs...)
@@ -117,23 +142,34 @@ func (p *ProxyStore) DeleteProfile(profileName string) error {
 	return p.insecure.DeleteProfile(profileName)
 }
 
-// GetHierarchicalValue routes to secure or insecure store based on property type.
-// For secure properties, it first checks the insecure store for a value, in the
-// case that environment variables are used. If no value is found, it will proceed
-// with secure store.
+// GetHierarchicalValue implements three-layer priority for secure properties:
+// 1. Environment variables (highest priority)
+// 2. Secure store (keyring)
+// 3. Config file (lowest priority)
+// For non-secure properties, checks env vars first, then config file.
 func (p *ProxyStore) GetHierarchicalValue(profileName string, propertyName string) any {
-	val := p.insecure.GetHierarchicalValue(profileName, propertyName)
-
-	if isSecureProperty(propertyName) && val == nil {
-		return p.secure.Get(profileName, propertyName)
+	// Layer 1: Check environment variables first (if environment store is available)
+	if p.environment != nil {
+		if envVal := p.environment.GetHierarchicalValue(profileName, propertyName); envVal != nil && envVal != "" {
+			return envVal
+		}
 	}
 
-	return val
+	// For secure properties, check secure store before insecure store
+	if isSecureProperty(propertyName) && p.secure != nil {
+		// Layer 2: Check secure store (keyring)
+		if secureVal := p.secure.Get(profileName, propertyName); secureVal != "" {
+			return secureVal
+		}
+	}
+
+	// Layer 3: Fall back to insecure config file
+	return p.insecure.GetHierarchicalValue(profileName, propertyName)
 }
 
 // SetProfileValue routes to secure or insecure store based on property type.
 func (p *ProxyStore) SetProfileValue(profileName string, propertyName string, value any) {
-	if isSecureProperty(propertyName) {
+	if isSecureProperty(propertyName) && p.secure != nil {
 		if v, ok := value.(string); ok {
 			p.secure.Set(profileName, propertyName, v)
 		}
@@ -144,7 +180,7 @@ func (p *ProxyStore) SetProfileValue(profileName string, propertyName string, va
 
 // GetProfileValue routes to secure or insecure store based on property type.
 func (p *ProxyStore) GetProfileValue(profileName string, propertyName string) any {
-	if isSecureProperty(propertyName) {
+	if isSecureProperty(propertyName) && p.secure != nil {
 		return p.secure.Get(profileName, propertyName)
 	}
 	return p.insecure.GetProfileValue(profileName, propertyName)
@@ -157,7 +193,7 @@ func (p *ProxyStore) GetProfileStringMap(profileName string) map[string]string {
 
 // SetGlobalValue routes to secure or insecure store based on property type.
 func (p *ProxyStore) SetGlobalValue(propertyName string, value any) {
-	if isSecureProperty(propertyName) {
+	if isSecureProperty(propertyName) && p.secure != nil {
 		if v, ok := value.(string); ok {
 			p.secure.Set(DefaultProfile, propertyName, v)
 		}
@@ -166,16 +202,34 @@ func (p *ProxyStore) SetGlobalValue(propertyName string, value any) {
 	p.insecure.SetGlobalValue(propertyName, value)
 }
 
-// GetGlobalValue routes to secure or insecure store based on property type.
+// GetGlobalValue implements three-layer priority for secure properties:
+// 1. Environment variables (highest priority)
+// 2. Secure store (keyring)
+// 3. Config file (lowest priority)
 func (p *ProxyStore) GetGlobalValue(propertyName string) any {
-	if isSecureProperty(propertyName) {
-		return p.secure.Get(DefaultProfile, propertyName)
+	// Layer 1: Check environment variables first (if environment store is available)
+	if p.environment != nil {
+		if envVal := p.environment.GetGlobalValue(propertyName); envVal != nil && envVal != "" {
+			return envVal
+		}
 	}
+
+	// For secure properties, check secure store before insecure store
+	if isSecureProperty(propertyName) && p.secure != nil {
+		// Layer 2: Check secure store (keyring)
+		if secureVal := p.secure.Get(DefaultProfile, propertyName); secureVal != "" {
+			return secureVal
+		}
+	}
+
+	// Layer 3: Fall back to insecure config file
 	return p.insecure.GetGlobalValue(propertyName)
 }
 
-// IsSetGlobal checks only insecure store for global property existence as
-// no secure properties are global
+// IsSetGlobal checks if a global property is set in any store.
 func (p *ProxyStore) IsSetGlobal(propertyName string) bool {
+	if p.environment != nil && p.environment.IsSetGlobal(propertyName) {
+		return true
+	}
 	return p.insecure.IsSetGlobal(propertyName)
 }

--- a/config/proxy_store.go
+++ b/config/proxy_store.go
@@ -81,19 +81,19 @@ func NewStoreWithEnvOption(loadEnvVars bool) (Store, error) {
 // NewStore creates a ProxyStore if we have environment or secure storage,
 // otherwise returns insecure store directly.
 func NewStore(environment Store, insecure Store, secureStore SecureStore) Store {
-	var secure SecureStore
+	var secStore SecureStore
 	if secureStore != nil && secureStore.Available() {
-		secure = secureStore
+		secStore = secureStore
 	}
 
-	if environment == nil && secure == nil {
+	if environment == nil && secStore == nil {
 		return insecure
 	}
 
 	return &ProxyStore{
 		environment: environment,
 		insecure:    insecure,
-		secure:      secure,
+		secure:      secStore,
 	}
 }
 

--- a/config/proxy_store_test.go
+++ b/config/proxy_store_test.go
@@ -26,6 +26,7 @@ import (
 const (
 	testProfileName = "test-profile"
 	testValue       = "test-value"
+	envVarTestValue = "env-var-value"
 )
 
 func TestNewStore(t *testing.T) {
@@ -319,15 +320,14 @@ func TestGetHierarchicalValue_EnvVarPriority(t *testing.T) {
 	}
 
 	profileName := "test"
-	envVarValue := "env-var-value"
 
 	// Test that env var value is returned (no secure or insecure store calls)
 	environment.EXPECT().
 		GetHierarchicalValue(profileName, ClientIDField).
-		Return(envVarValue)
+		Return(envVarTestValue)
 
 	result := store.GetHierarchicalValue(profileName, ClientIDField)
-	assert.Equal(t, envVarValue, result)
+	assert.Equal(t, envVarTestValue, result)
 
 	// Test fallback: env returns nil -> check secure store
 	keyringValue := "keyring-value"
@@ -372,13 +372,11 @@ func TestGetGlobalValue_EnvVarPriority(t *testing.T) {
 		secure:      mockSecure,
 	}
 
-	envVarValue := "env-var-value"
-
 	// Test that env var value is returned (no secure or insecure store calls)
 	environment.EXPECT().
 		GetGlobalValue(ClientIDField).
-		Return(envVarValue)
+		Return(envVarTestValue)
 
 	result := store.GetGlobalValue(ClientIDField)
-	assert.Equal(t, envVarValue, result)
+	assert.Equal(t, envVarTestValue, result)
 }

--- a/config/proxy_store_test.go
+++ b/config/proxy_store_test.go
@@ -32,16 +32,31 @@ func TestNewStore(t *testing.T) {
 	tests := []struct {
 		name             string
 		secureAvailable  bool
+		hasEnvironment   bool
 		expectProxyStore bool
 	}{
 		{
-			name:             "secure store available - returns ProxyStore",
+			name:             "secure store available with env - returns ProxyStore",
 			secureAvailable:  true,
+			hasEnvironment:   true,
 			expectProxyStore: true,
 		},
 		{
-			name:             "secure store unavailable - returns insecure store",
+			name:             "secure store available without env - returns ProxyStore",
+			secureAvailable:  true,
+			hasEnvironment:   false,
+			expectProxyStore: true,
+		},
+		{
+			name:             "secure store unavailable with env - returns ProxyStore",
 			secureAvailable:  false,
+			hasEnvironment:   true,
+			expectProxyStore: true,
+		},
+		{
+			name:             "secure store unavailable without env - returns insecure store",
+			secureAvailable:  false,
+			hasEnvironment:   false,
 			expectProxyStore: false,
 		},
 	}
@@ -50,20 +65,29 @@ func TestNewStore(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
-			mockInsecure := mocks.NewMockStore(ctrl)
+			var environment Store
+			if tt.hasEnvironment {
+				environment = mocks.NewMockStore(ctrl)
+			}
+			insecure := mocks.NewMockStore(ctrl)
 			mockSecure := mocks.NewMockSecureStore(ctrl)
 
-			mockSecure.EXPECT().Available().Return(tt.secureAvailable)
+			mockSecure.EXPECT().Available().Return(tt.secureAvailable).AnyTimes()
 
-			store := NewStore(mockInsecure, mockSecure)
+			store := NewStore(environment, insecure, mockSecure)
 
 			if tt.expectProxyStore {
 				proxyStore, ok := store.(*ProxyStore)
 				require.True(t, ok, "Expected ProxyStore")
-				assert.Equal(t, mockInsecure, proxyStore.insecure)
-				assert.Equal(t, mockSecure, proxyStore.secure)
+				assert.Equal(t, environment, proxyStore.environment)
+				assert.Equal(t, insecure, proxyStore.insecure)
+				if tt.secureAvailable {
+					assert.Equal(t, mockSecure, proxyStore.secure)
+				} else {
+					assert.Nil(t, proxyStore.secure)
+				}
 			} else {
-				assert.Equal(t, mockInsecure, store)
+				assert.Equal(t, insecure, store)
 			}
 		})
 	}
@@ -72,12 +96,13 @@ func TestNewStore(t *testing.T) {
 func TestProxyStore_IsSecure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	mockInsecure := mocks.NewMockStore(ctrl)
+	environment := mocks.NewMockStore(ctrl)
+	insecure := mocks.NewMockStore(ctrl)
 	mockSecure := mocks.NewMockSecureStore(ctrl)
-
 	store := &ProxyStore{
-		insecure: mockInsecure,
-		secure:   mockSecure,
+		environment: environment,
+		insecure:    insecure,
+		secure:      mockSecure,
 	}
 
 	assert.True(t, store.IsSecure())
@@ -130,12 +155,14 @@ func TestProxyStore_PropertyRouting(t *testing.T) {
 			t.Run(method.name+"_"+tc.propertyName, func(t *testing.T) {
 				ctrl := gomock.NewController(t)
 
-				mockInsecure := mocks.NewMockStore(ctrl)
+				environment := mocks.NewMockStore(ctrl)
+				insecure := mocks.NewMockStore(ctrl)
 				mockSecure := mocks.NewMockSecureStore(ctrl)
 
 				store := &ProxyStore{
-					insecure: mockInsecure,
-					secure:   mockSecure,
+					environment: environment,
+					insecure:    insecure,
+					secure:      mockSecure,
 				}
 
 				method.testFunc(t, store, tc.propertyName, tc.isSecure)
@@ -150,13 +177,20 @@ func testGetHierarchicalValue(t *testing.T, store *ProxyStore, propertyName stri
 	expectedValue := testValue
 
 	if isSecure {
-		store.insecure.(*mocks.MockStore).EXPECT().
+		// Three-layer priority for secure properties:
+		// 1. Check environment variables (returns nil)
+		store.environment.(*mocks.MockStore).EXPECT().
 			GetHierarchicalValue(profileName, propertyName).
 			Return(nil)
+		// 2. Check secure store (returns value)
 		store.secure.(*mocks.MockSecureStore).EXPECT().
 			Get(profileName, propertyName).
 			Return(expectedValue)
 	} else {
+		// For non-secure: check env (returns nil), then insecure store
+		store.environment.(*mocks.MockStore).EXPECT().
+			GetHierarchicalValue(profileName, propertyName).
+			Return(nil)
 		store.insecure.(*mocks.MockStore).EXPECT().
 			GetHierarchicalValue(profileName, propertyName).
 			Return(expectedValue)
@@ -221,10 +255,20 @@ func testGetGlobalValue(t *testing.T, store *ProxyStore, propertyName string, is
 	expectedValue := testValue
 
 	if isSecure {
+		// Three-layer priority for secure properties:
+		// 1. Check environment variables (returns nil)
+		store.environment.(*mocks.MockStore).EXPECT().
+			GetGlobalValue(propertyName).
+			Return(nil)
+		// 2. Check secure store (returns value)
 		store.secure.(*mocks.MockSecureStore).EXPECT().
 			Get(DefaultProfile, propertyName).
 			Return(expectedValue)
 	} else {
+		// For non-secure: check env (returns nil), then insecure store
+		store.environment.(*mocks.MockStore).EXPECT().
+			GetGlobalValue(propertyName).
+			Return(nil)
 		store.insecure.(*mocks.MockStore).EXPECT().
 			GetGlobalValue(propertyName).
 			Return(expectedValue)
@@ -257,4 +301,84 @@ func TestIsSecureProperty(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestGetHierarchicalValue_EnvVarPriority tests that environment variables
+// take precedence over both secure store and insecure config for secure properties.
+func TestGetHierarchicalValue_EnvVarPriority(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	environment := mocks.NewMockStore(ctrl)
+	insecure := mocks.NewMockStore(ctrl)
+	mockSecure := mocks.NewMockSecureStore(ctrl)
+
+	store := &ProxyStore{
+		environment: environment,
+		insecure:    insecure,
+		secure:      mockSecure,
+	}
+
+	profileName := "test"
+	envVarValue := "env-var-value"
+
+	// Test that env var value is returned (no secure or insecure store calls)
+	environment.EXPECT().
+		GetHierarchicalValue(profileName, ClientIDField).
+		Return(envVarValue)
+
+	result := store.GetHierarchicalValue(profileName, ClientIDField)
+	assert.Equal(t, envVarValue, result)
+
+	// Test fallback: env returns nil -> check secure store
+	keyringValue := "keyring-value"
+	environment.EXPECT().
+		GetHierarchicalValue(profileName, ClientSecretField).
+		Return(nil)
+	mockSecure.EXPECT().
+		Get(profileName, ClientSecretField).
+		Return(keyringValue)
+
+	result = store.GetHierarchicalValue(profileName, ClientSecretField)
+	assert.Equal(t, keyringValue, result)
+
+	// Test fallback: env returns nil, secure returns empty -> check insecure store
+	insecureValue := "insecure-value"
+	environment.EXPECT().
+		GetHierarchicalValue(profileName, privateAPIKey).
+		Return(nil)
+	mockSecure.EXPECT().
+		Get(profileName, privateAPIKey).
+		Return("")
+	insecure.EXPECT().
+		GetHierarchicalValue(profileName, privateAPIKey).
+		Return(insecureValue)
+
+	result = store.GetHierarchicalValue(profileName, privateAPIKey)
+	assert.Equal(t, insecureValue, result)
+}
+
+// TestGetGlobalValue_EnvVarPriority tests that environment variables
+// take precedence over both secure store and insecure config for secure properties.
+func TestGetGlobalValue_EnvVarPriority(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	environment := mocks.NewMockStore(ctrl)
+	insecure := mocks.NewMockStore(ctrl)
+	mockSecure := mocks.NewMockSecureStore(ctrl)
+
+	store := &ProxyStore{
+		environment: environment,
+		insecure:    insecure,
+		secure:      mockSecure,
+	}
+
+	envVarValue := "env-var-value"
+
+	// Test that env var value is returned (no secure or insecure store calls)
+	environment.EXPECT().
+		GetGlobalValue(ClientIDField).
+		Return(envVarValue)
+
+	result := store.GetGlobalValue(ClientIDField)
+	assert.Equal(t, envVarValue, result)
 }


### PR DESCRIPTION
# Description
Previously, environment variables and config file values were loaded into a single Viper instance. When secure storage (keyring) was available and contained credentials, those values would shadow environment variables like `MONGODB_ATLAS_CLIENT_ID` and `MONGODB_ATLAS_CLIENT_SECRET`, causing authentication failures (CLOUDP-381648).

## Changes
Split the insecure store into two layers:
- environment: env-only Viper with in-memory filesystem
- insecure: file-only Viper with no env var loading

ProxyStore now resolves values in three layers:
1. Environment variables (highest priority)
2. Secure store/keyring (`nil` when unavailable)
3. Config file (lowest priority)

## Testing
- Updated unit tests
- Compiled the Atlas CLI locally and tried authenticating using service account credentials passed through environment variables.

Jira: [\[CLOUDP-381648\] Atlas CLI unable to use service account credentials](https://jira.mongodb.org/browse/CLOUDP-381648)