### PR TITLE
CLOUDP-383021: honor MONGODB_ATLAS_BASE_URL env var

### DIFF
--- a/config/viper_store.go
+++ b/config/viper_store.go
@@ -60,6 +60,14 @@ func NewViperStore(fs afero.Fs, loadEnvVars bool) (*ViperConfigStore, error) {
 		if hasMongoCLIEnvVars() {
 			v.SetEnvKeyReplacer(strings.NewReplacer(AtlasCLIEnvPrefix, MongoCLIEnvPrefix))
 		}
+
+		// The base_url alias below only applies to the config file, so the
+		// MONGODB_ATLAS_BASE_URL env var would otherwise be ignored. Bind both
+		// env vars to ops_manager_url; viper returns the first one set, giving
+		// MONGODB_ATLAS_OPS_MANAGER_URL precedence when both are present.
+		if err := v.BindEnv(OpsManagerURLField, AtlasCLIEnvPrefix+"_OPS_MANAGER_URL", AtlasCLIEnvPrefix+"_BASE_URL"); err != nil {
+			return nil, err
+		}
 	}
 
 	// aliases only work for a config file, this won't work for env variables

--- a/config/viper_store_test.go
+++ b/config/viper_store_test.go
@@ -1,0 +1,68 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+// CLOUDP-383021: MONGODB_ATLAS_BASE_URL must resolve the base URL. base_url is a
+// viper alias of ops_manager_url, but aliases only apply to the config file, so
+// without an explicit env binding the variable was silently ignored.
+func TestViperStore_BaseURLEnvVar(t *testing.T) {
+	tests := []struct {
+		name           string
+		opsManagerEnv  string
+		baseURLEnv     string
+		wantOpsManager string
+	}{
+		{
+			name:           "base url env var is honored",
+			baseURLEnv:     "https://cloud-dev.mongodb.com/",
+			wantOpsManager: "https://cloud-dev.mongodb.com/",
+		},
+		{
+			name:           "ops manager url env var still works",
+			opsManagerEnv:  "https://cloud-qa.mongodb.com/",
+			wantOpsManager: "https://cloud-qa.mongodb.com/",
+		},
+		{
+			name:           "ops manager url takes precedence when both are set",
+			opsManagerEnv:  "https://cloud-qa.mongodb.com/",
+			baseURLEnv:     "https://cloud-dev.mongodb.com/",
+			wantOpsManager: "https://cloud-qa.mongodb.com/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.opsManagerEnv != "" {
+				t.Setenv(AtlasCLIEnvPrefix+"_OPS_MANAGER_URL", tt.opsManagerEnv)
+			}
+			if tt.baseURLEnv != "" {
+				t.Setenv(AtlasCLIEnvPrefix+"_BASE_URL", tt.baseURLEnv)
+			}
+
+			store, err := NewViperStore(afero.NewMemMapFs(), true)
+			require.NoError(t, err)
+
+			profile := NewProfile(DefaultProfile, store)
+			require.Equal(t, tt.wantOpsManager, profile.OpsManagerURL())
+		})
+	}
+}

--- a/test/e2e/base_url_env_test.go
+++ b/test/e2e/base_url_env_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mongodb/atlas-cli-core/config"
+	"github.com/mongodb/atlas-cli-core/transport"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBaseURLEnvVarDrivesRequests is the integration regression test for
+// CLOUDP-383021. It wires the real config store, profile, and transport client
+// together to prove that MONGODB_ATLAS_BASE_URL actually steers outgoing
+// requests, not just that it resolves in the config layer.
+//
+// Service account auth is used because HTTPClientFromProfile feeds
+// OpsManagerURL() straight into the OAuth token URL, so a request to the client
+// only reaches our test server when the env var is honored. Before the fix
+// OpsManagerURL() was empty and the token request went to the production
+// default instead.
+func TestBaseURLEnvVarDrivesRequests(t *testing.T) {
+	var tokenRequests atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/oauth/token" {
+			tokenRequests.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"fake-token","token_type":"bearer","expires_in":3600}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Clear any inherited ops_manager_url so base_url is the only source for the
+	// URL. The e2e CI environment sets MONGODB_ATLAS_OPS_MANAGER_URL for the
+	// credential-based tests, and it correctly takes precedence over base_url.
+	t.Setenv("MONGODB_ATLAS_OPS_MANAGER_URL", "")
+	// auth_type is set explicitly so the service account branch is taken
+	// without depending on AuthType()'s credential inference.
+	t.Setenv("MONGODB_ATLAS_AUTH_TYPE", string(config.ServiceAccount))
+	t.Setenv("MONGODB_ATLAS_CLIENT_ID", "test-client-id")
+	t.Setenv("MONGODB_ATLAS_CLIENT_SECRET", "test-client-secret")
+	t.Setenv("MONGODB_ATLAS_BASE_URL", server.URL)
+
+	store, err := config.NewViperStore(afero.NewMemMapFs(), true)
+	require.NoError(t, err)
+	profile := config.NewProfile(config.DefaultProfile, store)
+
+	require.Equal(t, config.ServiceAccount, profile.AuthType())
+	require.Equal(t, server.URL, profile.OpsManagerURL())
+
+	client, err := transport.HTTPClientFromProfile(profile, "test", transport.Default())
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL+"/api/atlas/v2/orgs", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Positive(t, tokenRequests.Load(),
+		"OAuth token request should have reached the MONGODB_ATLAS_BASE_URL host")
+}


### PR DESCRIPTION
## Summary

`MONGODB_ATLAS_BASE_URL` was silently ignored; the CLI only honored `MONGODB_ATLAS_OPS_MANAGER_URL` and otherwise fell back to the default production base URL.

`base_url` is registered as a viper alias of `ops_manager_url`, but viper aliases only apply to the config file, not environment variables. When `base_url` is resolved, viper rewrites it to `ops_manager_url` *before* the env lookup, so `MONGODB_ATLAS_BASE_URL` was never read.

The fix binds the `ops_manager_url` key to both env var names via `BindEnv`, which reads the literal names and sidesteps the alias. Viper returns the first one set, so `MONGODB_ATLAS_OPS_MANAGER_URL` keeps precedence when both are present (non-breaking for anyone relying on the current behavior).

Jira: https://jira.mongodb.org/browse/CLOUDP-383021

## Test plan

* Unit test `TestViperStore_BaseURLEnvVar` (`config/viper_store_test.go`): `base_url` resolves the URL (failed before the fix), `ops_manager_url` still works, and `ops_manager_url` wins when both are set.
* Integration test `TestBaseURLEnvVarDrivesRequests` (`test/e2e/base_url_env_test.go`): wires the real config store, profile, and transport client together, then asserts the OAuth token request actually reaches the host from `MONGODB_ATLAS_BASE_URL`. Fails on master (`OpsManagerURL()` resolves to `""`), passes with the fix.
* `go test ./...`, `go vet`, `gofmt` all clean.
* End-to-end: built `atlas` against this branch and pointed each env var at a local capture server. `MONGODB_ATLAS_BASE_URL` now routes requests to the configured URL; previously it captured nothing and hit production.

## Notes for reviewers

* The "Might be fixed by CLOUDP-381648" comment on the ticket doesn't hold -- no commit touched this path and the bug reproduced on current `master`.
* Precedence is a product decision: this PR gives `MONGODB_ATLAS_OPS_MANAGER_URL` priority. If `BASE_URL` should win instead, swap the `BindEnv` argument order.
* Separate latent bug spotted while writing the integration test (not fixed here): `Profile.AuthType()` (`config/profile.go`) calls the package-level `ClientID()`/`ClientSecret()`, which read the global `Default()` profile rather than the receiver `p`. Service-account inference therefore ignores a non-default profile's own credentials. Worth a follow-up ticket.