### PR TITLE
CLOUDP-417599: bump go to 1.26 and upgrade golangci-lint to fix coverage job

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -120,6 +120,16 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Install gocovmerge
+        # gocovmerge transitively pulls golang.org/x/tools, which now requires
+        # Go >= 1.25. actions/setup-go pins GOTOOLCHAIN=local for the job, so the
+        # install fails under the go.mod toolchain (1.24.x). GOTOOLCHAIN=auto does
+        # not help: the toolchain is selected up-front from the repo's go.mod
+        # (go 1.24.x) and the x/tools requirement is only discovered later during
+        # import resolution, so no upgrade is triggered. Set an explicit floor of
+        # go1.25.0 (with +auto to allow further upgrades) just for this step; the
+        # rest of the job keeps the pinned toolchain.
+        env:
+          GOTOOLCHAIN: go1.25.0+auto
         run: go install github.com/wadey/gocovmerge@latest
       - name: Download unit coverage
         uses: actions/download-artifact@v8

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -23,9 +23,9 @@ jobs:
           go-version-file: 'go.mod'
           cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
-          version: v2.1.6
+          version: v2.11.0
   unit-tests:
     env:
       COVERAGE: coverage.out

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -120,16 +120,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Install gocovmerge
-        # gocovmerge transitively pulls golang.org/x/tools, which now requires
-        # Go >= 1.25. actions/setup-go pins GOTOOLCHAIN=local for the job, so the
-        # install fails under the go.mod toolchain (1.24.x). GOTOOLCHAIN=auto does
-        # not help: the toolchain is selected up-front from the repo's go.mod
-        # (go 1.24.x) and the x/tools requirement is only discovered later during
-        # import resolution, so no upgrade is triggered. Set an explicit floor of
-        # go1.25.0 (with +auto to allow further upgrades) just for this step; the
-        # rest of the job keeps the pinned toolchain.
-        env:
-          GOTOOLCHAIN: go1.25.0+auto
         run: go install github.com/wadey/gocovmerge@latest
       - name: Download unit coverage
         uses: actions/download-artifact@v8

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/atlas-cli-core
 
-go 1.24.2
+go 1.26
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -41,7 +41,7 @@ func TestNewAccessTokenTransport(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, accessTokenTransport)
 
-	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
 	resp, err := accessTokenTransport.RoundTrip(req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -81,7 +81,7 @@ func TestNewServiceAccountTransport(t *testing.T) {
 	}))
 	defer server.Close()
 
-	req := httptest.NewRequest(http.MethodGet, server.URL, nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
 	resp, err := client.Transport.RoundTrip(req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)


### PR DESCRIPTION
## Summary

The `coverage` job in `.github/workflows/code-health.yml` was failing on `master` and every PR (e.g. run [24460524508](https://github.com/mongodb/atlas-cli-core/actions/runs/24460524508)). It's **independent of application code** — it started when `golang.org/x/tools` published versions requiring Go >= 1.25.

### Root cause

`go install github.com/wadey/gocovmerge@latest` transitively pulls `golang.org/x/tools/cover`, and the latest `x/tools` now requires `go >= 1.25.0`. `actions/setup-go` installed Go from `go.mod` (`go 1.24.2`) and pinned `GOTOOLCHAIN=local`, so the toolchain couldn't upgrade and the install died:

```
go: golang.org/x/tools requires go >= 1.25.0 (running go 1.24.2; GOTOOLCHAIN=local)
```

### Fix — align this library's Go version with the ecosystem

This library was the outlier: its consumers are already on Go 1.26 (`mongodb-atlas-cli` → `go 1.26`, `atlas-cli-plugin-kubernetes` → `go 1.26.4`). So the fix is to bring atlas-cli-core in line:

1. **`go.mod`**: `go 1.24.2` → `go 1.26`. `setup-go` now installs Go 1.26, which satisfies `x/tools`, so the `gocovmerge` install (and the coverage job) works with no per-step toolchain hack. `go mod tidy` produces no other changes.
2. **`.github/workflows/code-health.yml`**: bump golangci-lint `v2.1.6` → `v2.11.0` (matching `atlas-cli-plugin-kubernetes`) and the `golangci-lint-action` pin to the revision used by `mongodb-atlas-cli`. Required because golangci-lint v2.1.6 is built with Go 1.24 and refuses to lint a module targeting 1.26 (`the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.26)`).
3. **`transport/transport_test.go`**: the newer linter flags two `noctx` issues; fixed by switching `httptest.NewRequest` → `httptest.NewRequestWithContext(t.Context(), ...)`.
