### PR TITLE
fix(transport): Fixes fetching new access token on every use of Service Account transport

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -439,6 +439,28 @@ func (p *Profile) Token() (*auth.Token, error) {
 	return t, nil
 }
 
+// ServiceAccountToken returns the persisted service-account access token.
+// Unlike Token(), it does not require a refresh token (service accounts have none);
+// the expiry is derived from the JWT claims so callers can reuse the token until it
+// expires instead of minting a new one on every invocation.
+func ServiceAccountToken() (*auth.Token, error) { return Default().ServiceAccountToken() }
+func (p *Profile) ServiceAccountToken() (*auth.Token, error) {
+	if p.AccessToken() == "" {
+		return nil, nil
+	}
+	c, err := p.tokenClaims()
+	if err != nil || c.ExpiresAt == nil {
+		// The persisted access token is not a usable JWT (or carries no expiry), so we can't
+		// safely reuse it; report no token and let the caller mint a fresh one.
+		return nil, nil //nolint:nilerr // a non-JWT token is intentionally treated as "no token"
+	}
+	return &auth.Token{
+		AccessToken: p.AccessToken(),
+		TokenType:   "Bearer",
+		Expiry:      c.ExpiresAt.Time,
+	}, nil
+}
+
 // AccessTokenSubject will return the encoded subject in a JWT.
 // This method won't verify the token signature, it's only safe to use to get the token claims.
 func AccessTokenSubject() (string, error) { return Default().AccessTokenSubject() }

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -20,7 +20,9 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/mongodb/atlas-cli-core/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -438,4 +440,44 @@ func TestWithProfile_Multiple_Profiles(t *testing.T) {
 	stillRetrieved1, ok := ProfileFromContext(ctx1)
 	require.True(t, ok)
 	assert.Equal(t, "profile1", stillRetrieved1.name)
+}
+
+// jwtWithExpiry builds an unsigned-verification-safe JWT string carrying the given expiry.
+func jwtWithExpiry(t *testing.T, exp time.Time) string {
+	t.Helper()
+	claims := jwt.RegisteredClaims{ExpiresAt: jwt.NewNumericDate(exp)}
+	s, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	return s
+}
+
+func TestProfile_ServiceAccountToken(t *testing.T) {
+	t.Run("returns nil when no access token is persisted", func(t *testing.T) {
+		p := NewProfile("test", NewInMemoryStore())
+		tok, err := p.ServiceAccountToken()
+		require.NoError(t, err)
+		assert.Nil(t, tok)
+	})
+
+	t.Run("returns nil when the persisted access token is not a JWT", func(t *testing.T) {
+		p := NewProfile("test", NewInMemoryStore())
+		p.SetAccessToken("not-a-jwt")
+		tok, err := p.ServiceAccountToken()
+		require.NoError(t, err)
+		assert.Nil(t, tok, "a non-JWT token should be treated as no token so a fresh one is minted")
+	})
+
+	t.Run("returns token with expiry parsed from the JWT and no refresh token", func(t *testing.T) {
+		exp := time.Now().Add(45 * time.Minute).Truncate(time.Second)
+		p := NewProfile("test", NewInMemoryStore())
+		p.SetAccessToken(jwtWithExpiry(t, exp))
+
+		tok, err := p.ServiceAccountToken()
+		require.NoError(t, err)
+		require.NotNil(t, tok)
+		assert.Equal(t, p.AccessToken(), tok.AccessToken)
+		assert.Equal(t, "Bearer", tok.TokenType)
+		assert.Empty(t, tok.RefreshToken, "service account tokens have no refresh token")
+		assert.WithinDuration(t, exp, tok.Expiry, time.Second)
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	go.mongodb.org/atlas v0.38.0
 	go.mongodb.org/atlas-sdk/v20250312006 v20250312006.0.0
 	go.uber.org/mock v0.6.0
+	golang.org/x/oauth2 v0.30.0
 )
 
 require (
@@ -32,7 +33,6 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.27.0 // indirect
-	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect

--- a/test/e2e/transport_test.go
+++ b/test/e2e/transport_test.go
@@ -84,8 +84,7 @@ func TestServiceAccountTransport(t *testing.T) {
 
 // TestServiceAccountTokenReuse verifies that a persisted service-account token is reused across
 // separate client constructions (each construction simulates a new CLI invocation), so repeated
-// API calls do not mint a new token every time. This exercises the fix for CLOUDP-418568 where the
-// per-service-account active-token limit was being exhausted.
+// API calls do not mint a new token every time.
 func TestServiceAccountTokenReuse(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")

--- a/test/e2e/transport_test.go
+++ b/test/e2e/transport_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/mongodb/atlas-cli-core/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	atlasauth "go.mongodb.org/atlas/auth"
+	"golang.org/x/oauth2"
 )
 
 // TestDigestTransport tests the digest authentication transport through an actual Atlas API call.
@@ -62,7 +64,7 @@ func TestServiceAccountTransport(t *testing.T) {
 	config.SetOpsManagerURL(tc.BaseURL)
 	defer config.SetOpsManagerURL(tmp)
 	// Test the service account client from transport package
-	client := transport.NewServiceAccountClientWithHost(tc.ClientID, tc.ClientSecret, tc.BaseURL)
+	client := transport.NewServiceAccountClientWithHost(t.Context(), tc.ClientID, tc.ClientSecret, tc.BaseURL, "e2e-test", nil, func(_ *oauth2.Token) error { return nil })
 	require.NotNil(t, client)
 
 	// Test actual API call using the service account
@@ -78,4 +80,73 @@ func TestServiceAccountTransport(t *testing.T) {
 
 	assert.Equal(t, 200, resp.StatusCode, "Should get successful response with service account")
 	t.Logf("Service account authentication successful, status: %d", resp.StatusCode)
+}
+
+// TestServiceAccountTokenReuse verifies that a persisted service-account token is reused across
+// separate client constructions (each construction simulates a new CLI invocation), so repeated
+// API calls do not mint a new token every time. This exercises the fix for CLOUDP-418568 where the
+// per-service-account active-token limit was being exhausted.
+func TestServiceAccountTokenReuse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tc := internal.NewTestCredentials(t)
+	tc.CreateServiceAccount()
+
+	tmp := config.OpsManagerURL()
+	config.SetOpsManagerURL(tc.BaseURL)
+	defer config.SetOpsManagerURL(tmp)
+
+	const version = "e2e-test"
+	url := tc.BaseURL + "api/atlas/v2/orgs"
+
+	// doCall performs an authenticated GET and asserts a 200, mirroring a single CLI command.
+	doCall := func(t *testing.T, client *http.Client) {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+		require.NoError(t, err)
+		req.Header.Set("Accept", internal.AcceptHeader)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+
+	// First "invocation": no persisted token, so exactly one token is minted and captured.
+	var minted []*oauth2.Token
+	client1 := transport.NewServiceAccountClientWithHost(t.Context(), tc.ClientID, tc.ClientSecret, tc.BaseURL, version, nil,
+		func(tok *oauth2.Token) error {
+			minted = append(minted, tok)
+			return nil
+		})
+	require.NotNil(t, client1)
+	doCall(t, client1)
+
+	require.Len(t, minted, 1, "first invocation should mint and persist exactly one token")
+	seedToken := minted[0]
+	require.NotEmpty(t, seedToken.AccessToken)
+
+	// Subsequent "invocations": seed each new client from the persisted token. No new token should
+	// be minted, and the calls must still succeed using the reused token.
+	seed := &atlasauth.Token{
+		AccessToken: seedToken.AccessToken,
+		TokenType:   "Bearer",
+		Expiry:      seedToken.Expiry,
+	}
+	const invocations = 5
+	for i := range invocations {
+		var newlyMinted []*oauth2.Token
+		client := transport.NewServiceAccountClientWithHost(t.Context(), tc.ClientID, tc.ClientSecret, tc.BaseURL, version, seed,
+			func(tok *oauth2.Token) error {
+				newlyMinted = append(newlyMinted, tok)
+				return nil
+			})
+		require.NotNil(t, client)
+		doCall(t, client)
+		assert.Empty(t, newlyMinted, "invocation %d should reuse the persisted token, not mint a new one", i+1)
+	}
+
+	assert.Len(t, minted, 1, "only the first invocation should have minted a token across %d total calls", invocations+1)
+	t.Logf("Service account token reused across %d invocations with a single mint", invocations+1)
 }

--- a/transport/client.go
+++ b/transport/client.go
@@ -15,10 +15,12 @@
 package transport
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/mongodb/atlas-cli-core/config"
 	"go.mongodb.org/atlas/auth"
+	"golang.org/x/oauth2"
 )
 
 //go:generate go tool go.uber.org/mock/mockgen -destination=mock_profile_provider.go -package=transport github.com/mongodb/atlas-cli-core/transport ProfileProvider
@@ -29,6 +31,7 @@ type ProfileProvider interface {
 	PublicAPIKey() string
 	PrivateAPIKey() string
 	Token() (*auth.Token, error)
+	ServiceAccountToken() (*auth.Token, error)
 	SetAccessToken(string)
 	SetRefreshToken(string)
 	Save() error
@@ -68,7 +71,15 @@ func HTTPClientFromProfile(profile ProfileProvider, version string, httpTranspor
 		// No token available, we're falling back to the default client (default branch)
 		fallthrough
 	case config.ServiceAccount:
-		return NewServiceAccountClientWithHost(profile.ClientID(), profile.ClientSecret(), profile.OpsManagerURL()), nil
+		seed, err := profile.ServiceAccountToken()
+		if err != nil {
+			return nil, err
+		}
+		return NewServiceAccountClientWithHost(context.Background(), profile.ClientID(), profile.ClientSecret(), profile.OpsManagerURL(), version, seed,
+			func(t *oauth2.Token) error {
+				profile.SetAccessToken(t.AccessToken)
+				return profile.Save()
+			}), nil
 	case config.NoAuth:
 		fallthrough
 	default:

--- a/transport/client_test.go
+++ b/transport/client_test.go
@@ -97,6 +97,7 @@ func TestHTTPClientFromProfile(t *testing.T) {
 				m.EXPECT().AuthType().Return(config.UserAccount)
 				m.EXPECT().Token().Return(nil, nil)
 				// Falls through to ServiceAccount case
+				m.EXPECT().ServiceAccountToken().Return(nil, nil)
 				m.EXPECT().ClientID().Return("client-id")
 				m.EXPECT().ClientSecret().Return("client-secret")
 				m.EXPECT().OpsManagerURL().Return("")
@@ -120,6 +121,7 @@ func TestHTTPClientFromProfile(t *testing.T) {
 			name: "Service Account authentication",
 			setupMock: func(m *MockProfileProvider) {
 				m.EXPECT().AuthType().Return(config.ServiceAccount)
+				m.EXPECT().ServiceAccountToken().Return(nil, nil)
 				m.EXPECT().ClientID().Return("client-id")
 				m.EXPECT().ClientSecret().Return("client-secret")
 				m.EXPECT().OpsManagerURL().Return("https://ops-manager.example.com")
@@ -135,6 +137,7 @@ func TestHTTPClientFromProfile(t *testing.T) {
 			name: "Service Account authentication with empty OpsManagerURL",
 			setupMock: func(m *MockProfileProvider) {
 				m.EXPECT().AuthType().Return(config.ServiceAccount)
+				m.EXPECT().ServiceAccountToken().Return(nil, nil)
 				m.EXPECT().ClientID().Return("client-id")
 				m.EXPECT().ClientSecret().Return("client-secret")
 				m.EXPECT().OpsManagerURL().Return("")

--- a/transport/mock_profile_provider.go
+++ b/transport/mock_profile_provider.go
@@ -139,6 +139,21 @@ func (mr *MockProfileProviderMockRecorder) Save() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockProfileProvider)(nil).Save))
 }
 
+// ServiceAccountToken mocks base method.
+func (m *MockProfileProvider) ServiceAccountToken() (*auth.Token, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAccountToken")
+	ret0, _ := ret[0].(*auth.Token)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceAccountToken indicates an expected call of ServiceAccountToken.
+func (mr *MockProfileProviderMockRecorder) ServiceAccountToken() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAccountToken", reflect.TypeOf((*MockProfileProvider)(nil).ServiceAccountToken))
+}
+
 // SetAccessToken mocks base method.
 func (m *MockProfileProvider) SetAccessToken(arg0 string) {
 	m.ctrl.T.Helper()

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mongodb/atlas-cli-core/config"
 	"go.mongodb.org/atlas-sdk/v20250312006/auth/clientcredentials"
 	atlasauth "go.mongodb.org/atlas/auth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -136,14 +137,55 @@ func (tr *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return tr.base.RoundTrip(req)
 }
 
+// persistingTokenSource wraps a token source and writes any newly minted token back to disk
+// via save, so it can be reused across CLI invocations instead of minting a new one each time.
+type persistingTokenSource struct {
+	src  oauth2.TokenSource
+	last string // access token last known to be saved to disk; empty means "save whatever comes back"
+	save func(*oauth2.Token) error
+}
+
+func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
+	t, err := p.src.Token()
+	if err != nil {
+		return nil, err
+	}
+	if t.AccessToken != p.last {
+		if err := p.save(t); err != nil {
+			return nil, err
+		}
+		p.last = t.AccessToken
+	}
+	return t, nil
+}
+
 // NewServiceAccountClientWithHost creates a new HTTP client configured for service account authentication.
 // This function does not return http.RoundTripper as atlas-sdk already packages a transport with the client.
-func NewServiceAccountClientWithHost(clientID, clientSecret, host string) *http.Client {
+// This function reuses a previously persisted access token until it expires, minting and persisting a new one only when
+// needed. This keeps a service account within its active-token limit (roughly one token per hour
+// instead of one per command). seed may be nil when no token has been persisted yet; save is called
+// whenever a new token is minted so it can be stored for the next invocation.
+func NewServiceAccountClientWithHost(ctx context.Context, clientID, clientSecret, host, version string, seed *atlasauth.Token, save func(*oauth2.Token) error) *http.Client {
 	cfg := clientcredentials.NewConfig(clientID, clientSecret)
 	if host != "" {
 		baseURL := strings.TrimSuffix(host, "/")
 		cfg.TokenURL = baseURL + clientcredentials.TokenAPIPath
 		cfg.RevokeURL = baseURL + clientcredentials.RevokeAPIPath
 	}
-	return cfg.Client(context.Background())
+
+	// The client-credentials source performs the 2-legged OAuth exchange to mint a fresh token, if needed.
+	src := cfg.TokenSource(ctx)
+	last := ""
+	if seed != nil {
+		seedToken := &oauth2.Token{AccessToken: seed.AccessToken, TokenType: "Bearer", Expiry: seed.Expiry}
+		if seedToken.Valid() {
+			// Reuse the persisted token while valid; fall back to minting a new one on expiry.
+			src = oauth2.ReuseTokenSource(seedToken, src)
+			last = seedToken.AccessToken
+		}
+	}
+
+	client := oauth2.NewClient(ctx, &persistingTokenSource{src: src, last: last, save: save})
+	client.Transport = &clientcredentials.Transport{Base: client.Transport, UserAgent: config.UserAgent(version)}
+	return client
 }

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -115,7 +115,7 @@ func newSAServer(t *testing.T) *saServer {
 }
 
 // TestNewServiceAccountClient_ReusesSeedToken verifies a valid persisted token is reused, so no new
-// token is minted (the fix for the per-service-account active-token limit).
+// token is minted.
 func TestNewServiceAccountClient_ReusesSeedToken(t *testing.T) {
 	server := newSAServer(t)
 	defer server.Close()

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/auth"
+	"golang.org/x/oauth2"
 )
 
 func TestNewAccessTokenTransport(t *testing.T) {
@@ -69,7 +70,7 @@ func TestNewServiceAccountTransport(t *testing.T) {
 	clientID := "mock-client-id"
 	clientSecret := "mock-client-secret" //nolint:gosec
 
-	client := NewServiceAccountClientWithHost(clientID, clientSecret, tokenServer.URL)
+	client := NewServiceAccountClientWithHost(t.Context(), clientID, clientSecret, tokenServer.URL, "1.0.0", nil, func(_ *oauth2.Token) error { return nil })
 	require.NotNil(t, client)
 
 	// Create request to check authentication header
@@ -85,6 +86,124 @@ func TestNewServiceAccountTransport(t *testing.T) {
 	resp, err := client.Transport.RoundTrip(req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
+}
+
+// saServer is a test server that mints "minted-token" at the OAuth token endpoint (counting hits)
+// and records the Authorization header seen on any other (resource) request.
+type saServer struct {
+	*httptest.Server
+	mints    int
+	lastAuth string
+}
+
+func newSAServer(t *testing.T) *saServer {
+	t.Helper()
+	s := &saServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/api/oauth/token") {
+			s.mints++
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := w.Write([]byte(`{"access_token":"minted-token","token_type":"bearer","expires_in":3600}`)); err != nil {
+				t.Errorf("Failed to write token response: %v", err)
+			}
+			return
+		}
+		s.lastAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	return s
+}
+
+// TestNewServiceAccountClient_ReusesSeedToken verifies a valid persisted token is reused, so no new
+// token is minted (the fix for the per-service-account active-token limit).
+func TestNewServiceAccountClient_ReusesSeedToken(t *testing.T) {
+	server := newSAServer(t)
+	defer server.Close()
+
+	seed := &auth.Token{AccessToken: "persisted-token", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour)}
+	saved := 0
+	client := NewServiceAccountClientWithHost(t.Context(), "id", "secret", server.URL, "1.0.0", seed, func(_ *oauth2.Token) error {
+		saved++
+		return nil
+	})
+	require.NotNil(t, client)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "Bearer persisted-token", server.lastAuth, "should reuse persisted token")
+	assert.Equal(t, 0, server.mints, "no token should be minted when a valid one is persisted")
+	assert.Equal(t, 0, saved, "no save when reusing an unchanged token")
+}
+
+// TestNewServiceAccountClient_MintsAndPersistsWhenNoSeed verifies a new token is minted and persisted
+// when nothing is stored yet.
+func TestNewServiceAccountClient_MintsAndPersistsWhenNoSeed(t *testing.T) {
+	server := newSAServer(t)
+	defer server.Close()
+
+	var savedToken string
+	client := NewServiceAccountClientWithHost(t.Context(), "id", "secret", server.URL, "1.0.0", nil, func(tok *oauth2.Token) error {
+		savedToken = tok.AccessToken
+		return nil
+	})
+	require.NotNil(t, client)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "Bearer minted-token", server.lastAuth)
+	assert.Equal(t, 1, server.mints, "a token should be minted when none is persisted")
+	assert.Equal(t, "minted-token", savedToken, "newly minted token should be persisted for reuse")
+}
+
+// TestNewServiceAccountClient_ExpiredSeedMints verifies an expired persisted token is not reused.
+func TestNewServiceAccountClient_ExpiredSeedMints(t *testing.T) {
+	server := newSAServer(t)
+	defer server.Close()
+
+	seed := &auth.Token{AccessToken: "expired-token", TokenType: "Bearer", Expiry: time.Now().Add(-time.Hour)}
+	client := NewServiceAccountClientWithHost(t.Context(), "id", "secret", server.URL, "1.0.0", seed, func(_ *oauth2.Token) error { return nil })
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "Bearer minted-token", server.lastAuth)
+	assert.Equal(t, 1, server.mints, "an expired persisted token should trigger a mint")
+}
+
+// TestPersistingTokenSource verifies the wrapper only persists a token when it changes.
+func TestPersistingTokenSource(t *testing.T) {
+	tok := &oauth2.Token{AccessToken: "same", Expiry: time.Now().Add(time.Hour)}
+	saves := 0
+	ps := &persistingTokenSource{
+		src:  oauth2.StaticTokenSource(tok),
+		last: "same",
+		save: func(_ *oauth2.Token) error { saves++; return nil },
+	}
+	got, err := ps.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "same", got.AccessToken)
+	assert.Equal(t, 0, saves, "unchanged token should not be persisted")
+
+	ps2 := &persistingTokenSource{
+		src:  oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "new", Expiry: time.Now().Add(time.Hour)}),
+		last: "old",
+		save: func(_ *oauth2.Token) error { saves++; return nil },
+	}
+	got, err = ps2.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "new", got.AccessToken)
+	assert.Equal(t, 1, saves, "changed token should be persisted once")
 }
 
 func TestDefaultTransport(t *testing.T) {


### PR DESCRIPTION
## Proposed changes
JIRA ticket: [CLOUDP-418568](https://jira.mongodb.org/browse/CLOUDP-418568)

### Summary

When authenticating with an SA, the Atlas CLI minted a new access token on every command. Service accounts are capped at 100 active tokens per hour, so any workflow that runs many CLI commands (e.g. an automated agent using a GSA) quickly exhausts the limit and fails with:
`oauth2: "access_denied" "Access Token limit reached. Please use the existing Access Tokens or create a new Service Account"`

This PR persists the SA access token and reuses it until it expires (~1 token/hour instead of 1/command).

### Root cause

`transport.NewServiceAccountClientWithHost` built the client via `clientcredentials.Config.Client(ctx)`. Each CLI command is a new process, so the OAuth2 client-credentials source minted and cached a token only in-process, then discarded it on exit. Nothing was written to disk, unlike the UserAccount flow which already persists its token.

### Fix

`NewServiceAccountClientWithHost` now composes token sources:
- Seeds an `oauth2.ReuseTokenSource` from the token persisted on disk (loaded via the new `config.ServiceAccountToken()` accessor — returns the access token + JWT-derived expiry, no refresh token, leaving Token()/UserAccount behavior untouched).
- Wraps it in a small persisting TokenSource that writes any newly minted token back through the existing SetAccessToken + Save accessors (stored in the existing access_token field).

Result: a valid persisted token is reused across invocations; a new one is minted (and saved) only when none exists or the current one has expired. UserAccount, API-key, and no-auth paths are unchanged. Logout already clears access_token, so the persisted SA token is cleaned up on logout.

**Note:** SA profiles will now also have an access token attriute:
```
> atlas config describe sa-profile
SETTING         VALUE
access_token    [redacted - source: secure storage]  << new field for SA profiles
auth_type       service_account
client_id       [redacted - source: secure storage]
client_secret   [redacted - source: secure storage]
output          plaintext
service         cloud
```

### Reproduction (before the fix)

Ran the CLI with an SA profile in a loop:
```
for i in $(seq 1 120); do atlas projects list --profile sa -o json; done
```
Fails at call **101** with Access Token limit reached, confirming one token minted per command.

### Verification (after the fix)

- Unit tests (transport, config): reuse (valid seed , no mint, no save), mint-and-persist (no seed, 1 mint saved), expired-seed (1 mint and save), and persistingTokenSource only saving on change; plus ServiceAccountToken() accessor tests including the non-JWT/no-expiry fallback.
- E2E (test/e2e): TestServiceAccountTokenReuse creates a real SA, then constructs a fresh client per "invocation" seeded from the persisted token across 6 calls. Asserts exactly 1 token minted total.
- Live CLI: reran the 120-call loop against a fresh SA profile with the fixed binary and got 0 token-limit errors (previously failed at 101). Debug tracing (temporary, not in this PR) confirmed the same access-token fingerprint reused across separate invocations until its expiry.